### PR TITLE
Add GH issue template to standardize the info we include on cards

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue-template.md
@@ -1,0 +1,21 @@
+---
+name: Generic issue template
+about: Use this template to request work and provide Goals, Tasks, Additional Context,
+  and/or Resources
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Goals
+* _What outcome(s) we are hoping to accomplish_
+
+### Tasks
+- [ ] _Key pieces of work that will need to be done to accomplish our goal(s)_
+
+### Additional Context
+* _Any additional information that would be useful to share about this work (e.g., dependencies, constraints, previous work that's been done, info already known, etc)_
+
+### Resources
+* _Links to useful related info (e.g., articles, help docs, etc)_


### PR DESCRIPTION
Expected that we may create different templates for feature work, bugs, etc.