### PR TITLE
Establish Engineering Team roles

### DIFF
--- a/docs/how_we_work.md
+++ b/docs/how_we_work.md
@@ -32,11 +32,16 @@
 
 ## Engineering team roles
 
+### Tech Lead role
+
+Amy Mok will act as our Tech Lead for this project, with backup support from Alex Soble and Carly Jugler.
+
 ### Table of responsibilities
 
 Task/Responsibility | Primary | Backup
 -- | -- | --
-More tech-lead-specific things… Keep tabs on the different eng streams and whether they’re flowing smoothly individually and togetherEnsure engs have a good sense of their roles; eng team roles/shape matched to the work that needs doing | AM | ARS
+Keep tabs on the different eng streams and whether they’re flowing smoothly individually and together<br>
+Ensure engs have a good sense of their roles; eng team roles/shape matched to the work that needs doing | AM | ARS
 Meet with PM to provide initial perspective on draft milestones, cycles, stories | AM | CJ
 Meet with OCIO to represent project, fill out ATO docs** | ARS | AM, CJ
 Guide eng team to technical decisions | ARS | AM, CJ
@@ -44,6 +49,7 @@ Implementation — back end | CJ | AM
 Implementation — front end | ARS | CJ
 Implementation — database migration** | AM | CJ
 (TBD) Train up partner tech lead |   |  
+
 
 **this is a big effort!
 

--- a/docs/how_we_work.md
+++ b/docs/how_we_work.md
@@ -33,7 +33,8 @@
 ## Engineering team roles
 
 ### Table of responsibilities
-  | Primary | Backup
+
+Task/Responsibility | Primary | Backup
 -- | -- | --
 More tech-lead-specific things… Keep tabs on the different eng streams and whether they’re flowing smoothly individually and togetherEnsure engs have a good sense of their roles; eng team roles/shape matched to the work that needs doing | AM | ARS
 Meet with PM to provide initial perspective on draft milestones, cycles, stories | AM | CJ
@@ -42,7 +43,8 @@ Guide eng team to technical decisions | ARS | AM, CJ
 Implementation — back end | CJ | AM
 Implementation — front end | ARS | CJ
 Implementation — database migration** | AM | CJ
-(future) Train up partner tech lead |   |  
+(TBD) Train up partner tech lead |   |  
+
 **this is a big effort!
 
 ## Git flow practices

--- a/docs/how_we_work.md
+++ b/docs/how_we_work.md
@@ -40,7 +40,7 @@ Amy Mok (AM) will act as our Tech Lead for this project, with backup support fro
 
 Task/Responsibility | Primary | Backup
 -- | -- | --
-Keep tabs on the different eng streams and whether they’re flowing smoothly individually and together<br>
+Keep tabs on the different eng streams and whether they’re flowing smoothly individually and together | AM | ARS
 Ensure engs have a good sense of their roles; eng team roles/shape matched to the work that needs doing | AM | ARS
 Meet with PM to provide initial perspective on draft milestones, cycles, stories | AM | CJ
 Meet with OCIO to represent project, fill out ATO docs** | ARS | AM, CJ

--- a/docs/how_we_work.md
+++ b/docs/how_we_work.md
@@ -34,7 +34,7 @@
 
 ### Tech Lead role
 
-Amy Mok will act as our Tech Lead for this project, with backup support from Alex Soble and Carly Jugler.
+Amy Mok (AM) will act as our Tech Lead for this project, with backup support from Alex Soble (ARS) and Carly Jugler (CJ).
 
 ### Table of responsibilities
 

--- a/docs/how_we_work.md
+++ b/docs/how_we_work.md
@@ -4,7 +4,7 @@
 
 *Version*: Draft, ~V0.9
 
-## Engineering team practices 
+## Engineering team practices
 
 ### We will review each other’s code. 
 * *What*: 	All code will be code reviewed and approved by at least one other team member before it is accepted and merged.  (Exception: typos, spelling fixes.) We will prioritize reviewing each other’s code and unblocking teammates above our own software development work. 
@@ -29,6 +29,21 @@
 ### We will aim for small, focused Pull Requests that map to issues in our backlog. 
 * *What*:	We will write each pull request to accomplish one small, cohesive change. This change will map back to an issue for reference. We will include a link to the associated issue for each pull request. We may need more than one pull request to implement a given issue.
 * *Why*:	Small and focused pull requests will make code review faster and easier.  If there’s a need to roll back a change, it can also be done more easily if we do not have a big change or many different changes in a pull request.  By mapping pull requests back to issues, it can help the team track our progress on our work.
+
+## Engineering team roles
+
+### Table of responsibilities
+  | Primary | Backup
+-- | -- | --
+More tech-lead-specific things… Keep tabs on the different eng streams and whether they’re flowing smoothly individually and togetherEnsure engs have a good sense of their roles; eng team roles/shape matched to the work that needs doing | AM | ARS
+Meet with PM to provide initial perspective on draft milestones, cycles, stories | AM | CJ
+Meet with OCIO to represent project, fill out ATO docs** | ARS | AM, CJ
+Guide eng team to technical decisions | ARS | AM, CJ
+Implementation — back end | CJ | AM
+Implementation — front end | ARS | CJ
+Implementation — database migration** | AM | CJ
+(future) Train up partner tech lead |   |  
+**this is a big effort!
 
 ## Git flow practices
 


### PR DESCRIPTION
### What changed
Added "Engineering Team roles" section to `how_we_work.md`

@amymok @alexsoble I wasn't sure exactly what to put under the "Tech Lead role" subheading. Very open to suggestions there! Especially, would love your feedback @amymok since you're the Tech Lead after all :)

### Addresses
Linked issue #56 

### Preview link:
https://github.com/18F/OPRE-Unicorn/blob/0061fa980d01d800f278cb360c14465c945d8d91/docs/how_we_work.md