### PR TITLE
Create .gitattributes for better compatibility with Windows-based devs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Explicitly declare text files we want to always be normalized and converted on checkout.
+*.py text diff=python
+*.md text
+*.js text
+*.html text
+
+# Denote all files that are truly binary and should not be modified.
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.svg binary
+*.png binary
+*.jpg binary
+*.mp3 binary
+*.jpg binary
+*.jpeg binary


### PR DESCRIPTION
## Sources

+ https://stackoverflow.com/questions/21472971/what-is-the-purpose-of-text-auto-in-gitattributes-file
+ https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more
+ https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+ https://git-scm.com/docs/gitattributes

## Issue 

+ Closes #52.

## Reviewer notes

Hmmm, how best to review this one? A very rigorous review would involve messing with line endings on your local machine and verifying that the `.gitattributes` enforces the right line endings, I guess? But that would probably be overkill. 

The overall idea here is that having `.gitattributes` up front sets us up for success if/when a developer with a Windows machine [a partner tech lead??] joins us down the line. 

So in my mind, "this looks like a sensible default `.gitattributes`" should be sufficient for a 👍  review. 